### PR TITLE
fix(package): remove ngFactory before building

### DIFF
--- a/.vscode/angulardoc.json
+++ b/.vscode/angulardoc.json
@@ -1,0 +1,12 @@
+{
+  "repoId": "57abb57c-7adb-4976-ba3e-6fdd9af8401b",
+  "directoryFilter": [
+    "!typings",
+    "!node_modules",
+    "!.vscode"
+  ],
+  "fileFilter": [
+    "**/!(*.*spec).ts"
+  ],
+  "lastSync": 0
+}

--- a/package.json
+++ b/package.json
@@ -4,12 +4,12 @@
   "main": "index.js",
   "repository": {},
   "scripts": {
-    "start": "npm run build && npm run server",
+    "start": "rm -rf src/ngfactory && npm run build && npm run server",
     "build": "webpack -p",
-    "prebuild": "npm run build:ngc",
+    "prebuild": "rm -rf src/ngfactory && npm run build:ngc",
     "build:ngc": "ngc",
     "server": "nodemon dist/server.js",
-    "prewatch": "npm run build:ngc",
+    "prewatch": "rm -rf src/ngfactory && npm run build:ngc",
     "watch": "webpack --watch"
   },
   "engines": {


### PR DESCRIPTION
When starting a build its necessary to remove the ngfactory create from the previous builds. This can be done in some prehooks on the package.json I believe.