### PR TITLE
fix(server-transfer): Fix issue with setting doctype on index.html

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html>
 <head>
   <meta charset="UTF-8">

--- a/src/modules/transfer-state/server-transfer-state.ts
+++ b/src/modules/transfer-state/server-transfer-state.ts
@@ -21,7 +21,7 @@ export class ServerTransferState extends TransferState {
         data: {}
       });
 
-      const head = document.children[0].children[0];
+      const head = document.children[1].children[0];
       if (head.name !== 'head') {
         throw new Error('Please have <head> as the first element in your document');
       }


### PR DESCRIPTION
When setting the DOCTYPE property of the index.html the head becomes the second element in the DOM. I think this might be a common situation for people so thought maybe would be useful to throw this in here.

Cheers;)